### PR TITLE
chore: composer update for illuminate contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1",
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16.0",
         "ext-simplexml": "*",
         "ext-dom": "*"


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand compatibility with newer versions of a dependency.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-R22): Updated the `illuminate/contracts` dependency to include support for version `^12.0` in addition to the previously supported versions (`^10.0|^11.0`).